### PR TITLE
Handle invalid last modified date and fix value to match docs

### DIFF
--- a/NDbfReader/HeaderLoader.cs
+++ b/NDbfReader/HeaderLoader.cs
@@ -223,9 +223,10 @@ namespace NDbfReader
             byte month = buffer[MONTH_OFFSET];
             byte day = buffer[DAY_OFFSET];
 
+            // prevent exception for invalid month or day
             if (month == 0 || day == 0)
             {
-                return DateTime.MinValue; // prevent exception for invalid month and day
+                return DateTime.MinValue;
             }
 
             // YY is added to a base of 1900 decimal to determine the actual year giving a range of 1900-2155

--- a/NDbfReader/HeaderLoader.cs
+++ b/NDbfReader/HeaderLoader.cs
@@ -228,7 +228,9 @@ namespace NDbfReader
                 return DateTime.MinValue; // prevent exception for invalid month and day
             }
 
-            return new DateTime((year > DateTime.Now.Year % 1000 ? 1900 : 2000) + year, month, day);
+            // YY is added to a base of 1900 decimal to determine the actual year giving a range of 1900-2155
+            // (http://www.dbase.com/KnowledgeBase/int/db7_file_fmt.htm).
+            return new DateTime(1900 + year, month, day);
         }
 
         private LoadColumnsResult LoadColumns(Stream stream, byte firstColumnByte)

--- a/NDbfReader/HeaderLoader.cs
+++ b/NDbfReader/HeaderLoader.cs
@@ -223,6 +223,11 @@ namespace NDbfReader
             byte month = buffer[MONTH_OFFSET];
             byte day = buffer[DAY_OFFSET];
 
+            if (month == 0 || day == 0)
+            {
+                return DateTime.MinValue; // prevent exception for invalid month and day
+            }
+
             return new DateTime((year > DateTime.Now.Year % 1000 ? 1900 : 2000) + year, month, day);
         }
 


### PR DESCRIPTION
Thanks for this library!

1. I was trying to read some dbase files with an invalid last modified date. This should fix it to be a bit more resilient, but perhaps there is better way?
2. I looked at the docs and they say: "Date of last update; in YYMMDD format.  Each byte contains the number as a binary.  YY is added to a base of 1900 decimal to determine the actual year. Therefore, YY has possible values from 0x00-0xFF, which allows for a range from 1900-2155." http://www.dbase.com/KnowledgeBase/int/db7_file_fmt.htm -- So I changed it to match that.